### PR TITLE
Facts for es

### DIFF
--- a/roles/openshift_logging/filter_plugins/generators.py
+++ b/roles/openshift_logging/filter_plugins/generators.py
@@ -1,0 +1,12 @@
+import random, string
+
+def random_word(source_alpha,length):
+    return ''.join(random.choice(source_alpha) for i in range(length))
+
+class FilterModule(object):
+    ''' OpenShift Logging Filters '''
+
+    def filters(self):
+        return {
+            'random_word': random_word
+        }

--- a/roles/openshift_logging/tasks/generate_pvcs.yaml
+++ b/roles/openshift_logging/tasks/generate_pvcs.yaml
@@ -1,18 +1,14 @@
 ---
-- name: Validate Elasticsearch cluster size to Generate PersistentVolumeClaims
-  fail: msg="The es_cluster_size may not be more then 1 less (or 0) then the number of Elasticsearch nodes already deployed"
-  when: "{{openshift_logging_facts.elasticsearch.deploymentconfigs | length - es_cluster_size | abs > 1}}"
-
-- name: Init PersistentVolumeClaims Pool
+- name: Init pool of PersistentVolumeClaim names
   set_fact: es_pvc_pool={{es_pvc_pool + [pvc_name]}}
   vars:
     es_pvc_pool: []
     pvc_name: "{{es_pvc_prefix}}-{{item| int +1}}"
-    start: "{{openshift_logging_facts.elasticsearch.pvcs.keys()| map('regex_search',es_pvc_prefix+'.*')|select('string')|list|length}}"
+    start: "{{es_pvc_names | map('regex_search',es_pvc_prefix+'.*')|select('string')|list|length}}"
   with_sequence: start={{start}} end={{es_cluster_size}}
   when:
     - es_pvc_size | search('^\d.*')
-    - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | length < es_cluster_size }}"
+    - "{{ es_dc_names | length < es_cluster_size }}"
 
 - name: Generating PersistentVolumeClaims
   template: src=pvc.j2 dest={{mktemp.stdout}}/templates/logging-{{obj_name}}-pvc.yaml

--- a/roles/openshift_logging/tasks/install_elasticsearch.yaml
+++ b/roles/openshift_logging/tasks/install_elasticsearch.yaml
@@ -1,23 +1,37 @@
 ---
-#- name: Check ES Install
-#  when: "{{ openshift_logging.facts.es.deploymentconfigs | list | count }} == 0"
+- name: Validate Elasticsearch cluster size
+  fail: msg="The es_cluster_size may not be scaled down more than 1 less (or 0) the number of Elasticsearch nodes already deployed"
+  when: "{{openshift_logging_facts.elasticsearch.deploymentconfigs | length - es_cluster_size | abs > 1}}"
+
+- name: Generate PersistentVolumeClaims
+  include: "{{ role_path}}/tasks/generate_pvcs.yaml"
+  vars:
+    es_pvc_names: "{{openshift_logging_facts.elasticsearch.pvcs.keys()}}"
+    es_dc_names: "{{openshift_logging_facts.elasticsearch.deploymentconfigs.keys()}}"
+
+- name: Init pool of DeploymentConfig names for Elasticsearch
+  set_fact: es_dc_pool={{es_dc_pool + [deploy_name]}}
+  vars:
+    component: es
+    es_cluster_name: "{{component}}"
+    deploy_name_prefix: "logging-{{component}}"
+    deploy_name: "{{deploy_name_prefix}}-{{'abcdefghijklmnopqrstuvwxyz0123456789'|random_word(8)}}"
+    es_dc_pool: []
+  with_sequence: count={{es_cluster_size - openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | length}}
+  when:
+   - "{{ openshift_logging_facts.elasticsearch.deploymentconfigs.keys() | length < es_cluster_size }}"
+    
+      
 - name: Generate elasticsearch deploymentconfig
-  template: src=es.j2 dest={{mktemp.stdout}}/templates/logging-es-dc.yaml
+  template: src=es.j2 dest={{mktemp.stdout}}/templates/logging-{{deploy_name}}-dc.yaml
   vars:
     component: es
     logging_component: elasticsearch
     deploy_name_prefix: "logging-{{component}}"
-    deploy_name: "{{deploy_name_prefix}}-abc123"
     image: "{{image_prefix}}logging-elasticsearch:{{image_version}}"
     es_cluster_name: "{{component}}"
-
-- name: Generate OPS elasticsearch deploymentconfig
-  template: src=es.j2 dest={{mktemp.stdout}}/templates/logging-es-ops-dc.yaml
-  vars:
-    component: es-ops
-    logging_component: elasticsearch
-    deploy_name_prefix: "logging-{{component}}"
-    deploy_name: "{{deploy_name_prefix}}-abc123"
-    image: "{{image_prefix}}logging-elasticsearch:{{image_version}}"
-    es_cluster_name: "{{component}}"
-  when: logging_use_ops
+    volume_names: "{{es_pvc_pool | default([])}}"
+    pvc_claim: "{{(volume_names | length > item.0) | ternary(volume_names[item.0], None)}}"
+    deploy_name: "{{item.1}}"
+  with_indexed_items:
+    - "{{es_dc_pool}}"

--- a/roles/openshift_logging/templates/es.j2
+++ b/roles/openshift_logging/templates/es.j2
@@ -94,4 +94,10 @@ spec:
           configMap:
             name: logging-elasticsearch
         - name: elasticsearch-storage
+{% if pvc_claim is defined and pvc_claim | trim | length > 0 %}    
+          persistentVolumeClaim:
+            claimName: {{pvc_claim}}
+{% else %}
           emptyDir: {}
+{% endif %}
+


### PR DESCRIPTION
Generates DCs for elasticsearch.  This marries up the PVC to the DCs but I think there are missing corner cases that are not covered.  Additionally, it does not handle OPS DC's but I think there must be a way to reconfigure a playbook and reuse it.  Might need some refactor of facts...
