### PR TITLE
Remove local action from cert gen

### DIFF
--- a/playbooks/common/openshift-cluster/openshift_logging.yml
+++ b/playbooks/common/openshift-cluster/openshift_logging.yml
@@ -1,4 +1,5 @@
 - name: OpenShift Aggregated Logging
   hosts: all
+  strategy: debug
   roles: 
   - openshift_logging

--- a/roles/openshift_logging/filter_plugins/generators.py
+++ b/roles/openshift_logging/filter_plugins/generators.py
@@ -1,12 +1,23 @@
 import random, string
+import shutil
+import sys
+import StringIO
 
 def random_word(source_alpha,length):
     return ''.join(random.choice(source_alpha) for i in range(length))
 
+def cat(filename):
+    buf = StringIO.StringIO()
+    with open(filename,'r') as f:
+        buf.seek(0)
+        shutil.copyfileobj(f,buf)
+    return buf.getvalue()
+    
 class FilterModule(object):
     ''' OpenShift Logging Filters '''
 
     def filters(self):
         return {
-            'random_word': random_word
+            'random_word': random_word,
+            'cat': cat
         }

--- a/roles/openshift_logging/meta/main.yaml
+++ b/roles/openshift_logging/meta/main.yaml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: openshift_common, openshift_deployment_type: 'origin' }
+  - { role: openshift_common, openshift_deployment_type: 'origin', become: True }

--- a/roles/openshift_logging/tasks/generate_jks_chain.yaml
+++ b/roles/openshift_logging/tasks/generate_jks_chain.yaml
@@ -17,13 +17,13 @@
     echo {{ (cert_ext.stdout is defined) | ternary( '-ext san=dns:localhost,ip:127.0.0.1','') }}{{ (cert_ext.stdout is defined) | ternary( cert_ext.stdout, '') }}
   register: extensions
 
-- local_action: stat path="{{mktemp.stdout}}/{{component}}.jks"
+- name: Checking for {{component}}.jks ...
+  stat: path="{{mktemp.stdout}}/{{component}}.jks"
   register: jks_file
-  become: no
 
-- local_action: stat path="{{mktemp.stdout}}/truststore.jks"
+- name: Checking for truststore...
+  stat: path="{{mktemp.stdout}}/truststore.jks"
   register: jks_truststore
-  become: no
 
 - block:
     - shell: >

--- a/roles/openshift_logging/tasks/generate_pems.yaml
+++ b/roles/openshift_logging/tasks/generate_pems.yaml
@@ -1,11 +1,11 @@
 ---
-- local_action: stat path="{{mktemp.stdout}}/{{component}}.key"
+- name: Checking for {{component}}.key
+  stat: path="{{mktemp.stdout}}/{{component}}.key"
   register: key_file
-  become: no
 
-- local_action: stat path="{{mktemp.stdout}}/{{component}}.crt"
+- name: Checking for {{component}}.crt
+  stat: path="{{mktemp.stdout}}/{{component}}.crt"
   register: cert_file
-  become: no
 
 - name: Creating cert req for {{component}}
   command: openssl req -out {{mktemp.stdout}}/{{component}}.csr -new -newkey rsa:2048 -keyout {{mktemp.stdout}}/{{component}}.key -subj "/CN={{component}}/OU=OpenShift/O=Logging/subjectAltName=DNS.1=localhost{{cert_ext.stdout}}" -days 712 -nodes

--- a/roles/openshift_logging/tasks/generate_secrets.yaml
+++ b/roles/openshift_logging/tasks/generate_secrets.yaml
@@ -3,8 +3,11 @@
   template: src=secret.j2 dest={{mktemp.stdout}}/templates/{{secret_name}}-secret.yaml
   vars:
     secret_name: logging-{{component}}
-    secrets: [{key: ca, value: "{{lookup('file', '{{mktemp.stdout}}/ca.crt')}}"},{key: key, value: "{{lookup('file', '{{mktemp.stdout}}/system.logging.{{component}}.key')}}"},{key: cert, value: "{{lookup('file', '{{mktemp.stdout}}/system.logging.{{component}}.crt')}}"}]
+    secrets: [{key: ca, value: "{{ ca_file | cat}}"}, {key: key, value: "{{comp_key_file | cat}}"},{key: cert, value: "{{comp_cert_file | cat}}"}]
     secret_keys: ["ca", "cert", "key"]
+    ca_file: "{{mktemp.stdout}}/ca.crt"
+    comp_key_file: "{{mktemp.stdout}}/system.logging.{{component}}.key"
+    comp_cert_file: "{{mktemp.stdout}}/system.logging.{{component}}.crt"
   with_items:
     - kibana
     - curator
@@ -14,13 +17,15 @@
   when: secret_name not in openshift_logging_facts.{{component}}.secrets or
         secret_keys | difference(openshift_logging_facts.{{component}}.secrets["{{secret_name}}"]["keys"]) | length != 0
 
-
 - name: Generating secrets for kibana proxy
   template: src=secret.j2 dest={{mktemp.stdout}}/templates/{{secret_name}}-secret.yaml
   vars:
     secret_name: logging-kibana-proxy
-    secrets: [{key: oauth-secret, value: "{{oauth_secret.stdout}}"},{key: session-secret, value: "{{session_secret.stdout}}"},{key: server-key, value: "{{lookup('file', '{{mktemp.stdout}}/kibana-internal.key')}}"},{key: server-cert, value: "{{lookup('file', '{{mktemp.stdout}}/kibana-internal.crt')}}"},{key: server-tls, value: "{{lookup('file', '{{mktemp.stdout}}/server-tls.json')}}"}]
+    secrets: [{key: oauth-secret, value: "{{oauth_secret.stdout}}"},{key: session-secret, value: "{{session_secret.stdout}}"},{key: server-key, value: "{{kibana_key_file | cat}}"},{key: server-cert, value: "{{kibana_cert_file | cat}}"},{key: server-tls, value: "{{server_tls_file | cat}}"}]
     secret_keys: ["server-tls.json", "server-key", "session-secret", "oauth-secret", "server-cert"]
+    kibana_key_file: "{{mktemp.stdout}}/kibana-internal.key"
+    kibana_cert_file: "{{mktemp.stdout}}/kibana-internal.crt"
+    server_tls_file: "{{mktemp.stdout}}/server-tls.json"
   when: secret_name not in openshift_logging_facts.kibana.secrets or
         secret_keys | difference(openshift_logging_facts.kibana.secrets["{{secret_name}}"]["keys"]) | length != 0
 

--- a/roles/openshift_logging/tasks/install_logging.yaml
+++ b/roles/openshift_logging/tasks/install_logging.yaml
@@ -2,14 +2,14 @@
 # This is the base configuration for installing the other components
 - name: Check for logging project already exists
   command: >
-    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get project {{logging_namespace}} -o jsonpath='{.metadata.name}'
+    {{ openshift.common.client_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig get project {{logging_namespace}} --no-headers
   register: logging_project_result
   ignore_errors: True
 
 - name: "Create logging project"
   command: >
     {{ openshift.common.admin_binary }} --config={{ mktemp.stdout }}/admin.kubeconfig new-project {{logging_namespace}}
-  when: logging_project_result.stdout == ""
+  when: logging_project_result.stdout.startswith("{{logging_namespace}}") == False
 
 - include: generate_certs.yaml
 

--- a/roles/openshift_logging/tasks/main.yaml
+++ b/roles/openshift_logging/tasks/main.yaml
@@ -15,7 +15,7 @@
   openshift_logging_facts:
     oc_bin: "{{openshift.common.client_binary}}"
     admin_kubeconfig: "{{mktemp.stdout}}/admin.kubeconfig"
-    logging_namespace: logging
+    logging_namespace: "{{logging_namespace}}"
 
 - name: Install logging
   include: "{{ role_path }}/tasks/install_{{ install_component }}.yaml"


### PR DESCRIPTION
This PR removes:

* dependency on local action
* assumes role dependency requires sudo

The one part I'm not sure about is the 'cat' task for the pems displays in the logging, at least if you have -vv enabled.  I'm not sure if that is a security risk.  Seems like it would be.